### PR TITLE
Add option to check properties by whitelist

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -13,6 +13,7 @@ import { run } from "./src/generate"
       asserts: true,
       defaultArrayCheckOption: "all",
       comment: true,
+      whitelist: true,
     },
   })
 })()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ program
     "all"
   )
   .option("-c, --comment", "generate JSDoc comments or not", false)
+  .option("--whitelist", "not allow non listed properties")
   .parse(process.argv)
 
 const option = program.opts<{
@@ -33,6 +34,7 @@ const option = program.opts<{
   watch: boolean
   defaultArrayCheckOption: ArrayCheckOption
   comment: boolean
+  whitelist: boolean
 }>()
 
 const cwd = process.cwd()
@@ -47,5 +49,6 @@ run({
     watch: option.watch,
     defaultArrayCheckOption: option.defaultArrayCheckOption,
     comment: option.comment,
+    whitelist: option.whitelist,
   },
 })

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -16,6 +16,7 @@ type GenerateOption = {
   watch: boolean
   defaultArrayCheckOption: ArrayCheckOption
   comment: boolean
+  whitelist: boolean
 }
 
 export async function run({
@@ -85,7 +86,7 @@ const generateAndWriteCodes = (
   program: ts.Program,
   files: string[],
   output: string,
-  { asserts, defaultArrayCheckOption, comment }: GenerateOption
+  { asserts, defaultArrayCheckOption, comment, whitelist }: GenerateOption
 ) => {
   const handler = new CompilerApiHandler(program)
 
@@ -118,7 +119,8 @@ const generateAndWriteCodes = (
     types,
     asserts,
     defaultArrayCheckOption,
-    comment
+    comment,
+    whitelist
   )
   writeFileSync(output, generatedCode)
 }


### PR DESCRIPTION
Add  option `--whitelist` to properties checking by whitelist like [class-validator](https://github.com/typestack/class-validator#whitelisting)

```
// Type definition

type User = {
  name: string
}
```

```
// use type predicate 

// OK
isUser({
  name: 'foo'
})

// NG
isUser({
  name: 'foo',
  age: 20
})
```