### PR TITLE
fix: support optional array property

### DIFF
--- a/example/types/object.ts
+++ b/example/types/object.ts
@@ -2,6 +2,7 @@ export type Obj = {
   name: string
   names: string[]
   maybeName?: string
+  maybeNames?: string[]
   hoge: () => void // should skip
   time: Date
 }

--- a/src/compiler-api/compiler-api-handler.ts
+++ b/src/compiler-api/compiler-api-handler.ts
@@ -196,7 +196,6 @@ export class CompilerApiHandler {
               propName: string
               type: to.TypeObject
             } => {
-              const typeNode = symbol.valueDeclaration?.type
               const declare = (symbol.declarations ?? [])[0]
               const type = declare
                 ? this.#typeChecker.getTypeOfSymbolAtLocation(symbol, declare)
@@ -204,23 +203,14 @@ export class CompilerApiHandler {
 
               return {
                 propName: String(symbol.escapedName),
-                type:
-                  typeNode && ts.isArrayTypeNode(typeNode)
-                    ? {
-                        __type: "ArrayTO",
-                        typeName: this.#typeToString(
-                          this.#typeChecker.getTypeFromTypeNode(typeNode)
-                        ),
-                        child: this.#extractArrayTFromTypeNode(typeNode),
-                      }
-                    : type
-                    ? this.#isCallable(type)
-                      ? skip()
-                      : this.#convertType(type)
-                    : {
-                        __type: "UnknownTO",
-                        kind: "prop",
-                      },
+                type: type
+                  ? this.#isCallable(type)
+                    ? skip()
+                    : this.#convertType(type)
+                  : {
+                      __type: "UnknownTO",
+                      kind: "prop",
+                    },
               }
             }
           )

--- a/tests/compiler-api/compiler-api-handler.test.ts
+++ b/tests/compiler-api/compiler-api-handler.test.ts
@@ -244,6 +244,27 @@ describe("convertType", () => {
         },
       },
       {
+        propName: "maybeNames",
+        type: {
+          __type: "UnionTO",
+          typeName: "string[] | undefined",
+          unions: [
+            {
+              __type: "SpecialTO",
+              kind: "undefined",
+            },
+            {
+              __type: "ArrayTO",
+              typeName: "string[]",
+              child: {
+                __type: "PrimitiveTO",
+                kind: "string",
+              },
+            },
+          ],
+        },
+      },
+      {
         propName: "time",
         type: {
           __type: "SpecialTO",
@@ -383,6 +404,27 @@ describe("convertType", () => {
             {
               __type: "PrimitiveTO",
               kind: "string",
+            },
+          ],
+        },
+      },
+      {
+        propName: "maybeNames",
+        type: {
+          typeName: "string[] | undefined",
+          __type: "UnionTO",
+          unions: [
+            {
+              __type: "SpecialTO",
+              kind: "undefined",
+            },
+            {
+              __type: "ArrayTO",
+              typeName: "string[]",
+              child: {
+                __type: "PrimitiveTO",
+                kind: "string",
+              },
             },
           ],
         },


### PR DESCRIPTION
Dear d-kimuson,

I found this project from your article.
And I'm currently using type-predicates-generator with swr.


Then... there is one behavior I would like to fix.
When an object type has an optional property and the type of the property is an array, it is not treated as `typename[] | undefined`, it treated as `typename[]`.
This pull request is a change to address this behavior.
If you don't mind, I would appreciate your confirmation.
(Sorry if I misunderstood how to fix it...)


As an example,
If there is the following file (in.ts),
and generate the type guards with the following command (and run prettier for format),
the output file (out.ts) will be as follows:

```typescript
// in.ts
export type User = {
  name: string;
  roleNames?: string[];
};
```

```bash
# execute type-predicates-generator and prettier
npx type-predicates-generator -f in.ts -o out.ts
npx prettier -w out.ts
```

```typescript
// out.ts(excerpted, expected)
export const isUser = (arg_0: unknown): arg_0 is User =>
  isObject(arg_0) &&
  "name" in arg_0 &&
  isString(arg_0["name"]) &&
  ((arg_1: unknown): boolean =>
    isUnion([
      isUndefined,
      (arg_2: unknown): boolean => isArray(isString)(arg_2),
    ])(arg_1))(arg_0["roleNames"]);

// out.ts(excerpted, actual)
export const isUser = (arg_0: unknown): arg_0 is User =>
  isObject(arg_0) &&
  "name" in arg_0 &&
  isString(arg_0["name"]) &&
  "roleNames" in arg_0 &&
  ((arg_1: unknown): boolean => isArray(isString)(arg_1))(arg_0["roleNames"]);
```


For now, by doing the following workarounds, we can get the expected results even before the merge.

```typescript
// in.ts
export type User = {
  name: string;
  roleNames?: string[] | undefined;
};
```


I checked that `yarn test` passes.
And I checked that I could get output same as what I was previously outputting with a workaround with replace `node_modules/type-predicates-generator/dist` of own project with `dist` output by `yarn build`, and execute `type-guard-generator`.

Excuse me while you are busy,
I would appreciate it if you could check it when you are free.

Thank you,
nil2