### PR TITLE
peerDependenciesを範囲指定に修正して`npm install`できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `type-predicates-generator` is a tool to automatically generate [type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) functions from type definitions.
 
+Requires TypeScript v4.4.4 or higher.
+
 ## Getting started
 
 It is available directly from `npx`.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
-    "typescript": "4.4.4"
+    "typescript": ">=4.4.4"
   },
   "dependencies": {
     "commander": "^8.3.0",


### PR DESCRIPTION
ref: https://github.com/d-kimuson/type-predicates-generator/issues/15

`peerDependencies`でTypeScriptが固定バージョンで指定されているため、プロジェクトで使うTypeScriptをその固定バージョンに合わせる、もしくは`--legacy-peer-deps`フラグを追加しないと`npm install`ができない状況です。

## やったこと

`peerDependencies`を範囲指定に修正し、READMEに必要なTypeScriptのバージョンの情報を追記しました。

## 参考

https://stackoverflow.com/a/66620869